### PR TITLE
small improvements

### DIFF
--- a/OnigRegex/ORegex.cs
+++ b/OnigRegex/ORegex.cs
@@ -56,7 +56,7 @@ namespace OnigRegex
         /// </summary>
         /// <param name="text">The text to search</param>
         /// <param name="offset">An offset from which to start</param>
-        /// <returns></returns>
+        /// <returns>A list of capture group matches</returns>
         public List<ORegexResult> SafeSearch(string text, int offset = 0)
         {
             if (disposed) throw new ObjectDisposedException("ORegex");
@@ -90,6 +90,12 @@ namespace OnigRegex
             return resultList;
         }
 
+        /// <summary>
+        /// Perform a search for the given text starting at the specified offset
+        /// </summary>
+        /// <param name="text">The text to search</param>
+        /// <param name="offset">An offset from which to start</param>
+        /// <returns>Nothing. Use MatchPosition and MatchLength to query the results</returns>
         public void Search(string text, int offset = 0)
         {
             if (disposed) throw new ObjectDisposedException("ORegex");
@@ -103,6 +109,11 @@ namespace OnigRegex
             regionSet = true;
         }
 
+        /// <summary>
+        /// Get the start match position of the specified capture group
+        /// </summary>
+        /// <param name="nth">The capture group index</param>
+        /// <returns>The position in the string that was searched where the specified capture group was matched</returns>
         public int MatchPosition(int nth)
         {
             if (disposed) throw new ObjectDisposedException("ORegex");
@@ -112,6 +123,11 @@ namespace OnigRegex
             return OnigInterop.onigwrap_pos(region, nth);
         }
 
+        /// <summary>
+        /// Get the length of the specified capture group match
+        /// </summary>
+        /// <param name="nth">The capture group index</param>
+        /// <returns>The length in the string that was matched inside the specified capture group</returns>
         public int MatchLength(int nth)
         {
             if (disposed) throw new ObjectDisposedException("ORegex");
@@ -121,6 +137,11 @@ namespace OnigRegex
             return OnigInterop.onigwrap_len(region, nth);
         }
 
+        /// <summary>
+        /// Get the text that matched inside the specified capture group
+        /// </summary>
+        /// <param name="nth">The capture group index</param>
+        /// <returns>The text that was matched inside the specified capture group</returns>
         public string Capture(int nth)
         {
             if (disposed) throw new ObjectDisposedException("ORegex");

--- a/OnigWrapConsoleTest/Program.cs
+++ b/OnigWrapConsoleTest/Program.cs
@@ -16,15 +16,37 @@ namespace OnigWrapConsoleTest
         /// <param name="args"></param>
         static void Main(string[] args)
         {
-            var text = "abcABC123";
-            var pattern = "[A-C]+";
+            var text = args?.Length == 0 ? "abcABC123" : args[0];
+            var pattern =  args?.Length < 2 ? @"\w(\p{L})(?=(\d))" : args[1];
+            var start_position = args?.Length < 3 ? 0 : int.Parse(args[2]);
 
             Console.WriteLine("Building ORegex({0})", text);
 
             using (var re = new ORegex(pattern, false))
             {
-                Console.WriteLine("Looking for {0} in {1}", pattern, text);
-                Console.WriteLine("Found a match at {0}", re.IndexIn(text));
+                Console.WriteLine("Looking for '{0}' in '{1}', starting at position {2}...", pattern, text, start_position);
+                var result = re.SafeSearch(text, start_position);
+                if (!result.Any())
+                {
+                    Console.WriteLine("No matches found.");
+                }
+                else
+                {
+                    foreach (var tuple in result.Select((i, m) => Tuple.Create(m, i)))
+                    {
+                        var index = tuple.Item1;
+                        var match = tuple.Item2;
+                        Console.WriteLine("Found capture group {3} at position {0} with length {1}: {2}", match.Position, match.Length, text.Substring(match.Position, match.Length), index);
+                    }
+                }
+            }
+
+            if (System.Diagnostics.Debugger.IsAttached)
+            {
+                // when running through Visual Studio, the console output window disappears immediately when the application exists, so prompt the user to continue
+                Console.WriteLine();
+                Console.WriteLine("Press any key to continue...");
+                Console.ReadKey();
             }
         }
     }

--- a/OnigWrapConsoleTest/Program.cs
+++ b/OnigWrapConsoleTest/Program.cs
@@ -20,7 +20,7 @@ namespace OnigWrapConsoleTest
             var pattern =  args?.Length < 2 ? @"\w(\p{L})(?=(\d))" : args[1];
             var start_position = args?.Length < 3 ? 0 : int.Parse(args[2]);
 
-            Console.WriteLine("Building ORegex({0})", text);
+            Console.WriteLine("Building ORegex({0})", pattern);
 
             using (var re = new ORegex(pattern, false))
             {

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Building
 First, get a copy of Onigmo or Oniguruma.
 
 * https://github.com/k-takata/Onigmo
-* http://www.geocities.jp/kosako3/oniguruma/ (We don't actively test against oniguruma, but it should work.)
+* https://github.com/kkos/oniguruma (We don't actively test against oniguruma, but it should work.)
 
-Copy oniguruma.h into the onigwrap folder, alongside onigwrap.c and onigwrap.h.
+Copy `oniguruma.h` into the `onigwrap` folder (or copy `onigmo.h` and rename it to `oniguruma.h` if using Onigmo), alongside `onigwrap.c` and `onigwrap.h`.
 
 From here, the build steps diverge for each platform:
 
@@ -26,7 +26,7 @@ Configure and build onig. The defaults should work, but Mono on Mac is usually 3
 
 `make`
 
-Copy .libs/libonig.a to the onigwrap folder.
+Copy `.libs/libonig.a` to the `onigwrap` folder.
 
 Now we build onigwrap:
 
@@ -37,15 +37,15 @@ Take the dylib and put it alongside your binary.
 Windows
 -------
 
-Build and configure onig. Copy the win32/Makefile and win32/config.h to onig's root directory and run `nmake`. If you're building Onig as 64 bit, you'll need to edit the Makefile and add /MACHINE:X64 to the LINKFLAGS
+Build and configure onig. Copy the `win32/Makefile` and `win32/config.h` to onig's root directory and run `nmake`. If you're building Onig as 64 bit, you'll need to edit the Makefile and add `/MACHINE:X64` to the LINKFLAGS
 
-Copy onig\_s.lib and oniguruma.h to the onigwrap folder.
+Copy `onig_s.lib` to the `onigwrap` folder.
 
-Build onigwrap:
+With the `onigwrap` folder as your working dir, build onigwrap:
 
 `cl.exe /DONIG_EXTERN=extern /D_USRDLL /D_WINDLL onigwrap.c /link /LTCG onig_s.lib /DLL /OUT:onigwrap.dll`
 
-Copy onigwrap.dll to the folder with your binary.
+Copy `onigwrap.dll` to the folder with your binary. (For example, `OnigRegexTests/bin/Debug` and `OnigWrapConsoleTest/bin/Debug`.)
 
 Linux
 -----
@@ -54,10 +54,10 @@ Build and configure onig. We need to prepare onig for static linking though, so 
 
 `./configure "CFLAGS=-fPIC"`
 
-Copy .libs/libonig.a to the onigwrap folder.
+Copy `.libs/libonig.a` to the `onigwrap` folder.
 
 Build onigwrap:
 
 `gcc -shared -fPIC onigwrap.c libonig.a -o libonigwrap.so`
 
-Copy libonigwrap.so alongside your binary.
+Copy `libonigwrap.so` alongside your binary.


### PR DESCRIPTION
Hi,

Thanks for this useful wrapper library. I have updated the build instructions in the readme slightly, to make it easier to understand, and fixed the URL to Oniguruma.

I have also tweaked the console test program to accept (optional) arguments to tell it what regex and what text to match and which position to start from. If there are no arguments, it uses the original text and pattern, so it can be used exactly like it was before. I also changed it to output the capture group matches. I believe these changes help to make the application useful for making small manual tests of Onigmo without detracting from the original purpose of verifying that the Onigmo dll can be loaded.

In an attempt to make the API slightly easier to understand for newcomers, I also added some doc comments that were missing.